### PR TITLE
Fix `$confirmUninstall` attribute access level

### DIFF
--- a/simplifycommerce.php
+++ b/simplifycommerce.php
@@ -45,11 +45,6 @@ class SimplifyCommerce extends PaymentModule
     /**
      * @var string
      */
-    protected $confirmUninstall;
-
-    /**
-     * @var string
-     */
     protected $controllerAdmin;
 
     /**


### PR DESCRIPTION



## Proposition

Don't override `$confirmUninstall` access level : 

See 
https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L75

```php
    /**
     * @var string Text to display when ask for confirmation on uninstall action
     */
    public $confirmUninstall;
```


## Additional information 

- PHP 7.3.30-1+ubuntu20.04.1+deb.sury.org+1 (cli) (built: Aug 26 2021 15:56:09) ( NTS )
- PrestaShop 1.7.7.5
- Apache2

![image](https://user-images.githubusercontent.com/16455155/133086855-da53a619-c9c2-45b4-a679-b8f082185e9b.png)
